### PR TITLE
Use NavigatorState in progress dialog callbacks

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.2"
+    version: "1.4.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -118,26 +118,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/dialog/show_progress_dialog.dart
+++ b/lib/dialog/show_progress_dialog.dart
@@ -11,15 +11,15 @@ import 'package:flutter_future_progress_dialog/dialog/result.dart';
 typedef Task<T> = Future<T> Function();
 
 Future<void> _callback<T>(
-  w.BuildContext context,
+  w.NavigatorState navigator,
   Task<T> task,
   w.Route<ProgressDialogResult<T>> route,
 ) async {
   final result = await task.result();
-  if (!context.mounted) {
+  if (!route.isActive) {
     return;
   }
-  w.Navigator.of(context).removeRoute(route, result);
+  navigator.removeRoute(route, result);
 }
 
 /// Shows a progress dialog while executing a Future task.
@@ -74,9 +74,11 @@ Future<ProgressDialogResult<T>> showProgressDialog<T>({
   bool fullscreenDialog = false,
   m.AnimationStyle? animationStyle,
 }) async {
+  final navigator = m.Navigator.of(context, rootNavigator: useRootNavigator);
+
   final themes = m.InheritedTheme.capture(
     from: context,
-    to: m.Navigator.of(context, rootNavigator: useRootNavigator).context,
+    to: navigator.context,
   );
 
   late final m.Route<ProgressDialogResult<T>> route;
@@ -84,7 +86,7 @@ Future<ProgressDialogResult<T>> showProgressDialog<T>({
   route = m.DialogRoute<ProgressDialogResult<T>>(
     context: context,
     builder: (context) => ExactlyOnce(
-      callback: () => _callback(context, future, route),
+      callback: () => _callback(navigator, future, route),
       child: builder?.call(context) ?? const ProgressBarDialog(),
     ),
     barrierColor: barrierColor ??
@@ -103,8 +105,7 @@ Future<ProgressDialogResult<T>> showProgressDialog<T>({
     fullscreenDialog: fullscreenDialog,
   );
 
-  final result = await m.Navigator.of(context, rootNavigator: useRootNavigator)
-      .push<ProgressDialogResult<T>>(route);
+  final result = await navigator.push<ProgressDialogResult<T>>(route);
 
   return result!;
 }
@@ -153,11 +154,13 @@ Future<ProgressDialogResult<T>> showCupertinoProgressDialog<T>({
   c.Color? barrierColor,
   bool? requestFocus,
 }) async {
+  final navigator = c.Navigator.of(context, rootNavigator: useRootNavigator);
+
   late final c.CupertinoDialogRoute<ProgressDialogResult<T>> route;
 
   route = c.CupertinoDialogRoute<ProgressDialogResult<T>>(
     builder: (context) => ExactlyOnce(
-      callback: () => _callback(context, future, route),
+      callback: () => _callback(navigator, future, route),
       child: builder?.call(context) ?? const CupertinoProgressBarDialog(),
     ),
     context: context,
@@ -167,8 +170,7 @@ Future<ProgressDialogResult<T>> showCupertinoProgressDialog<T>({
     anchorPoint: anchorPoint,
     requestFocus: requestFocus,
   );
-  final result = await c.Navigator.of(context, rootNavigator: useRootNavigator)
-      .push<ProgressDialogResult<T>>(route);
+  final result = await navigator.push<ProgressDialogResult<T>>(route);
   return result!;
 }
 

--- a/test/progress_dialog_test.dart
+++ b/test/progress_dialog_test.dart
@@ -41,6 +41,71 @@ void main() {
     expect((result as Success<String>).value, 'ok');
   });
 
+  // Regression test: when the dialog is on a nested navigator and that
+  // navigator is removed from the tree while the task is in-flight,
+  // the dialog's context becomes unmounted. The original _callback would
+  // check context.mounted, return early, and never call removeRoute —
+  // causing push() to resolve with null and result! to throw.
+  testWidgets(
+    'showProgressDialog does not crash when context unmounts before task completes',
+    (WidgetTester tester) async {
+      final taskCompleter = Completer<void>();
+      final showNestedNav = ValueNotifier(true);
+      late BuildContext nestedContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ValueListenableBuilder<bool>(
+            valueListenable: showNestedNav,
+            builder: (_, show, __) {
+              if (!show) return const SizedBox();
+              return Navigator(
+                onGenerateRoute: (_) => MaterialPageRoute(
+                  builder: (ctx) {
+                    nestedContext = ctx;
+                    return const SizedBox();
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Launch the dialog on the nested navigator.
+      showProgressDialog<String>(
+        context: nestedContext,
+        future: () async {
+          await taskCompleter.future;
+          return 'ok';
+        },
+        useRootNavigator: false,
+      ).ignore();
+
+      // Let the dialog build and ExactlyOnce fire _callback.
+      // Can't use pumpAndSettle here — the pending task keeps the dialog
+      // animating indefinitely, so we pump two frames manually: one to
+      // build the widget tree and one to fire the post-frame callback.
+      await tester.pump();
+      await tester.pump();
+
+      // Remove the nested navigator from the tree — this disposes all its
+      // routes and unmounts the dialog's context while the task is running.
+      showNestedNav.value = false;
+      await tester.pumpAndSettle();
+
+      // Complete the task after context has been unmounted.
+      taskCompleter.complete();
+      await tester.pumpAndSettle();
+
+      // With the old code, _callback returns early (context.mounted == false),
+      // removeRoute is never called, and push() resolves with null causing
+      // result! to throw.
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('showProgressDialog completes with some error', (WidgetTester tester) async {
     final completer = Completer<ProgressDialogResult<String>?>();
     dialogTest(BuildContext context) async {


### PR DESCRIPTION
Pass NavigatorState into _callback and call navigator.removeRoute instead of depending on a possibly unmounted BuildContext. Capture navigator.context for theming and push routes via that navigator. Check route.isActive (not context.mounted) so removing a nested navigator while a task is in-flight does not leave push() resolving null. Add a regression test for the nested-navigator removal case. Update example/pubspec.lock package versions and Dart SDK bound.