### PR TITLE
Bump package to 1.5.0 and update metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,34 @@
-## 1.0.0
+## 1.5.0
 
-* Initial library release.
+* Fixed crash when dialog context unmounts before task completes
+* Captured NavigatorState before async await to prevent null check errors
+* Moved library sources to `lib/src/` following standard Dart package layout
+* Replaced BSD-3 license with MIT
+* Updated example with Material, Cupertino, custom, and failure variants
+* Improved documentation and README
+* Removed FVM configuration (not needed for a library)
 
-## 1.1.0
+## 1.4.2
 
-* Migrated to `sealed class` usage for result handling.
+* Avoid using `Navigator.pop()` when closing progress dialog
 
-## 1.1.1
+## 1.4.1
 
-* Fixed nullable values in result.
+* Included examples in pub.dev
+* Improved code documentation
 
-## 1.2.0
+## 1.4.0
 
-* Updated flutter version
+* Changed signatures of classes to avoid interfering with other packages
+
+## 1.3.2
+
+* Fixed deprecation warnings
+* Fixed image in readme file
+
+## 1.3.1
+
+* Updated docs
 
 ## 1.3.0
 
@@ -20,24 +36,18 @@
 * Adaptive progress dialog
 * Updated flutter version
 
-## 1.3.1
+## 1.2.0
 
-* Updated docs
+* Updated flutter version
 
-## 1.3.2
+## 1.1.1
 
-* Fixed deprecation warnings
-* Fixed image in readme file
+* Fixed nullable values in result.
 
-## 1.4.0
+## 1.1.0
 
-* Changed signatures of classes to avoid interfering with other packages
+* Migrated to `sealed class` usage for result handling.
 
-## 1.4.1
+## 1.0.0
 
-* Included examples in pub.dev
-* Improved code documentation
-
-## 1.4.2
-
-* Avoid using `Navigator.pop()` when closing progress dialog
+* Initial library release.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,19 @@
 name: flutter_future_progress_dialog
-description: Allows to display progress dialog while the Future function is evaluated.
-version: 1.4.2
-homepage: https://github.com/nerdy-pro/flutter-progress-dialog
+description: Show a progress dialog while a Future runs and return the result. Supports Material, Cupertino, and adaptive styles with type-safe error handling.
+version: 1.5.0
+repository: https://github.com/nerdy-pro/flutter-progress-dialog
+issue_tracker: https://github.com/nerdy-pro/flutter-progress-dialog/issues
+
+topics:
+  - dialog
+  - progress
+  - async
+  - cupertino
+  - loading
+
+screenshots:
+  - description: Progress dialog demo showing Material, Cupertino, custom, and failure variants.
+    path: img/flutter_progress_dialog.gif
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
Update CHANGELOG with 1.5.0 release notes and reorganized history Bump version in pubspec.yaml and example/pubspec.lock to 1.5.0 Enhance pubspec with description, repository, issue tracker, topics, and screenshots